### PR TITLE
Update PBPK_PFOA_pksensi_version1.R

### DIFF
--- a/Code/PBPK_PFOA_pksensi_version1.R
+++ b/Code/PBPK_PFOA_pksensi_version1.R
@@ -92,7 +92,7 @@ Vfil = VfilC*BW/VTC  # Scaled filtrate compartment volume
 VG = VGC*BW/VTC  # Gut volume (L)
 VPlas = VPlasC*BW/VTC  # Scaled plasma volume(L)
 
-VSk = (Skinarea*Skinthickness)/1000  # Skin volume (L)
+VSk = (Skinarea*Skinthickness)/1000/VTC  # Skin volume (L)
 VR = 0.84*BW-VL-VF-VK-Vfil-VG-VPlas-VSk  # Rest of the body volume (L). Need to know where the number 0.84 comes from???
 
 
@@ -211,9 +211,9 @@ para <- unlist(c(data.frame(
   VG,
   VPlas,
   VSk,
-  VR,
-  Tm,
-  SkinTarea,
+  #VR,
+  #Tm,
+  #SkinTarea,
   AbsPFOA
   
 )))


### PR DESCRIPTION
To avoid error "Error in quantile.default(newX[, i], ...) : missing values and NaN's not allowed if 'na.rm' is FALSE" these parameters are removed