### PR TITLE
Introduced scaling/normalisation of the carciac output and organ volu…

### DIFF
--- a/Code/PBPK_PFOA_pksensi_version1.R
+++ b/Code/PBPK_PFOA_pksensi_version1.R
@@ -69,22 +69,25 @@ Skinthickness = 0.1 # Skin thickness (cm)
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ## Scaled cardiac output and blood flows##
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-QTC=QLC+QFC+QKC+QGC+QCP # Preparation for scaling
+
 QC = QCC*BW^0.75  # Cardiac output adjusted for BW (L/h)
 QCP = QC*(1-Htc)  # Cardiac output adjusted for plasma flow (L/h)
+
+QTC=QLC+QFC+QKC+QGC # Preparation for scaling
+
 QL = QLC*QCP/QTC  # Scaled plasma flow to liver (L/h)
 QF = QFC*QCP/QTC  # Scaled plasma flow to fat (L/h)
 QK = QKC*QCP/QTC  # Scaled plasma flow to kidney (L/h)
 
 QG = QGC*QCP/QTC  # Scaled plasma flow to gut (L/h)
 
-QSk <- QSkC*QCP*(Skinarea/SkinTarea)/QTC #ifelse(Dermconc>0.0,QSkC*QCP*(Skinarea/SkinTarea),0.0) # scaled plasma flow to the skin
+QSk <- QSkC*QCP*(Skinarea/SkinTarea)/QTC # scaled plasma flow to the skin
 
 QR = QCP-QL-QF-QK-QG-QSk # Plasma flow to the rest of the body.
 
 
 ## Scaled tissue volumes ##
-VTC = VLC+VLC+VKC+VfilC+VGC+VPlasC # Preparation for scaling 
+VTC = VLC+VFC+VKC+VfilC+VGC+VPlasC +(Skinarea*Skinthickness)/1000 # Preparation for scaling 
 VL = VLC*BW/VTC  # Scaled liver volume (L)
 VF = VFC*BW/VTC  # Scaled fat volume (L)
 VK = VKC*BW/VTC  # Scaled kidney volume (L)
@@ -92,7 +95,7 @@ Vfil = VfilC*BW/VTC  # Scaled filtrate compartment volume
 VG = VGC*BW/VTC  # Gut volume (L)
 VPlas = VPlasC*BW/VTC  # Scaled plasma volume(L)
 
-VSk = (Skinarea*Skinthickness)/1000  # Skin volume (L)
+VSk = (Skinarea*Skinthickness)/1000/VTC  # Skin volume (L)
 VR = 0.84*BW-VL-VF-VK-Vfil-VG-VPlas-VSk  # Rest of the body volume (L). Need to know where the number 0.84 comes from???
 
 
@@ -347,7 +350,7 @@ PFOAamount <- as.data.frame(results)
 Qbal = QCP-(QR+QL+QF+QK+QG+QSk) # Mass balance check for the cardiac output 
 print(Qbal)
 
-Vbal = (0.84*BW/VTC)-(VL+VF+VK+Vfil+VG+VPlas+VSk+VR)  # Mass balance check for the volumes
+Vbal = (0.84*BW)-(VL+VF+VK+Vfil+VG+VPlas+VSk+VR)  # Mass balance check for the volumes
 print(Vbal)
 
 PFOA_bal <- sum(PFOAamount[,"Input1"]+ PFOAamount[,"Input2"]- PFOAamount[,"APlas"]- # Mass balance for PFOA


### PR DESCRIPTION
…mes by divide all the scales blood flows and organ volumes on the totale cardiac fraction (QTC) and totale organ fractions (VTC), respectively. The cardiac output adjusted for plasma flow should not be a part of QTC, and was deleted. The VTC should also include the volume fraction of the skin, which was added. In addition, the Vbal (mass balance of the volume should not be devided on VTC, and this eas therefore deleted.